### PR TITLE
Component link text change and page title update

### DIFF
--- a/app/views/194384-data-page/mvp/layouts/content_layout.njk
+++ b/app/views/194384-data-page/mvp/layouts/content_layout.njk
@@ -10,7 +10,7 @@
 
     <div class="govuk-grid-column-full">
 
-      {# Start of trust content block #}
+      {# Start of basic content page block #}
 
       {% block contentContent %}
         Text goes here, override this by overriding the block

--- a/app/views/194384-data-page/mvp/layouts/content_layout.njk
+++ b/app/views/194384-data-page/mvp/layouts/content_layout.njk
@@ -1,6 +1,6 @@
 {% extends "/194384-data-page/mvp/layouts/content_main.njk" %}
 
-{% set pageTitle = "Here's my title" %}
+{% set pageTitle = "About the data we show" %}
 {% set pageHeading = pageTitle %}
 {% set pageCaption = "" %}
 

--- a/app/views/194384-data-page/mvp/layouts/content_layout.njk
+++ b/app/views/194384-data-page/mvp/layouts/content_layout.njk
@@ -1,6 +1,6 @@
 {% extends "/194384-data-page/mvp/layouts/content_main.njk" %}
 
-{% set pageTitle = "About the data we show" %}
+{% set pageTitle = "About the data we use" %}
 {% set pageHeading = pageTitle %}
 {% set pageCaption = "" %}
 

--- a/app/views/194384-data-page/mvp/layouts/content_layout.njk
+++ b/app/views/194384-data-page/mvp/layouts/content_layout.njk
@@ -1,0 +1,23 @@
+{% extends "/194384-data-page/mvp/layouts/content_main.njk" %}
+
+{% set pageTitle = "Here's my title" %}
+{% set pageHeading = pageTitle %}
+{% set pageCaption = "" %}
+
+{% block content %} 
+
+  <div class="govuk-grid-row">
+
+    <div class="govuk-grid-column-full">
+
+      {# Start of trust content block #}
+
+      {% block contentContent %}
+        Text goes here, override this by overriding the block
+      {% endblock %}
+
+    </div>
+  </div>
+
+{% endblock %}
+

--- a/app/views/194384-data-page/mvp/layouts/content_main.njk
+++ b/app/views/194384-data-page/mvp/layouts/content_main.njk
@@ -1,0 +1,78 @@
+{#
+For guidance on how to use layouts see:
+https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
+#}
+
+{% set serviceName = "Find information about academies and trusts" %}
+
+{% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
+
+{% from 'node_modules/dfe-frontend/packages/components/header/macro.njk' import header %}
+
+{################################# Page title #################################}
+{% block pageTitle %}
+    {% if subPage %}
+      {{subPage}} - {{pageTitle}} - {{serviceName}} - GOV.UK
+    {% else %}
+      {{pageTitle}} - {{serviceName}} - GOV.UK
+    {% endif %}
+{% endblock %} 
+
+{################################# Header #################################}
+{% block header %}
+  {{ header({
+      "showNav": "false",
+      "showSearch": "true",
+      "showHeaderActionLinks": "false",
+      "logoPath": "public/images",
+      "searchAction": "/search/",
+      "searchInputName": "keywords",
+      "logoAltText": "Department for Education",
+      "homeHref": "https://gov.uk",
+      "selectedNav": view,
+      "service": {
+        "name": serviceName,
+        "serviceUrl": "/"
+      }
+    })
+  }}
+{% endblock %}
+
+{################################# FIAT top #################################}
+{% set containerClasses = "fiat-max-width-0 govuk-!-margin-0" %}
+{% set mainClasses = "govuk-width-container" %}
+
+{# The Phase banner must be within a beforeContent block to butt up next to the DfE Header appropriately #}
+{% block beforeContent %}
+  <div class="fiat-top govuk-!-padding-top-3">
+    <div class="govuk-width-container ">
+
+      {# {% include "../parts/breadcrumbs.njk" %} #}
+
+      {# A check to see if any page outside of Index is being used. If true, show the Heading and Caption #}
+      {% if currentURL !== '/' %}
+        <div class="fiat-top-content">
+          <h1 class="govuk-heading-l fiat-trust-heading govuk-!-display-inline-block govuk-!-margin-bottom-3" style="text-transform: none;">
+            {{pageHeading | default("Abbey academies trust") }}
+          </h1>
+        </div>
+      {% endif %}
+
+    </div>
+  </div>
+
+  {# Primary navigation #}
+  {# {% include "/189473-sources-updates/mvp/parts/primary_nav.njk" %} #}
+
+{% endblock %}
+
+{# RSD Footer #}
+{% block footer %}
+  {% include "/189473-sources-updates/mvp/parts/rsd-footer.njk" %}
+{% endblock %}
+
+{################################# Bottom of file #################################}
+{% block scripts %}
+  {{ super() }}
+  {# <script src="/assets/javascripts/dfefrontend.min.js"></script> #}
+{% endblock %}

--- a/app/views/194384-data-page/mvp/layouts/content_main.njk
+++ b/app/views/194384-data-page/mvp/layouts/content_main.njk
@@ -68,7 +68,7 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
 
 {# RSD Footer #}
 {% block footer %}
-  {% include "/189473-sources-updates/mvp/parts/rsd-footer.njk" %}
+  {% include "/194384-data-page/mvp/parts/rsd-footer.njk" %}
 {% endblock %}
 
 {################################# Bottom of file #################################}

--- a/app/views/194384-data-page/mvp/pages/fiat-information.njk
+++ b/app/views/194384-data-page/mvp/pages/fiat-information.njk
@@ -1,42 +1,118 @@
-{% extends "/194384-data-page/mvp/layouts/content_layout.njk" %}
+{% extends "/189473-sources-updates/mvp/layouts/content_layout.njk" %}
 
 {# Custom block for the main content area of this page #}
 {% block contentContent %}
 
-<p class="govuk-body">
-    Some new copy RIGHT HERE.
+<!--Intro copy-->
+<p>
+    Find information about academies and trusts (FIAT) brings together data from different places. 
+  </p>
+
+  <p>
+    We do not own the information we show from other services. 
+  </p>
+  
+  <p>
+    This means we cannot:
+  </p>
+
+<!--Bullets - what this means-->
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>
+      control its quality
+    </li>
+    <li>
+      make changes to it
+    </li>
+    <li>
+      remove or replace it
+    </li>
+  </ul>
+
+<!--Intro copy 2 -->
+
+<p>
+To report a problem with data taken from another source, you must contact the service responsible for it. 
 </p>
 
-<p class="govuk-body">
-    The information you see on FIATs pages gets updated at different times depending on the type of data and when it becomes available.
+
+<!--h2 When we fetch data-->
+
+<h2 class="govuk-heading-m">How FIAT gets updated</h2>
+
+
+<!--Inset text-->
+
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{{ govukInsetText({
+text: 'When we talk about updating FIAT, we mean replacing the data currently being shown with a new copy from whoever maintains it.'
+}) }}
+
+
+<!--When we fetch data para -->
+
+<p>
+If there are changes that FIAT needs to reflect, providing the place we take the data from has been updated, you should see them the next time we take a copy.
+</p> 
+
+<p>
+We do this as often as we can so that the information you see is as up to date as possible. 
 </p>
 
-<p class="govuk-body">
-    For example, we update the information we take from Get information about schools once per day, but we only update Ofsted information once per year, after the latest inspection.
+
+<!--h3 daily-->
+
+<h3 class="govuk-heading-s">Things we update daily</h3>
+
+<!--Daily paras -->
+
+<p>
+Most FIAT information comes from <a href="https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/RSD.aspx">Regions Group tools and systems</a> or <a href="https://get-information-schools.service.gov.uk/">Get information about schools (GIAS)</a> and gets updated <strong>every morning</strong>. 
 </p>
 
-<h2 class="govuk-heading-m">
-    Checking FIAT's data
-</h2>
-
-<p class="govuk-body">
-    Pages that contain information FIAT takes from other places include an option to see where it came from.
+<p>
+This includes:
 </p>
 
-<p class="govuk-body">
-    Clicking this will show you:
-</p>
+<!--Daily morning bullets-->
 
 <ul class="govuk-list govuk-list--bullet">
 
-    <li>
-        the original source of the data
-    </li>
-
-    <li>
-        when it was last taken from there
-    </li>
-
+<li>
+names, addresses and reference numbers
+</li>
+<li>
+current academies in a trust 
+</li>
+<li>
+details of any academies in the pipeline
+</li>
 </ul>
+
+
+<!--h3 Ofsted data-->
+
+<h3 class="govuk-heading-s">Ofsted reports</h3>
+
+<!--Ofsted data para -->
+
+
+<p>
+We take Ofsted information from the <a href="https://www.gov.uk/government/collections/maintained-schools-and-academies-inspections-and-outcomes-official-statistics">state-funded schools statistics: management information</a> report, which gets updated <strong>every month</strong>.
+</p>
+
+<p>
+Adding data from the report is a manual process. This means we cannot give an exact date for when FIAT will show it. 
+</p>
+
+<!--h3 Other data-->
+
+<h3 class="govuk-heading-s">Other data</h3>
+
+<p>
+FIAT also takes some information from <a href="https://explore-education-statistics.service.gov.uk/">Explore education statistics</a> which is published <strong>each year.</strong>
+</p>
 
 {% endblock %}

--- a/app/views/194384-data-page/mvp/pages/fiat-information.njk
+++ b/app/views/194384-data-page/mvp/pages/fiat-information.njk
@@ -1,4 +1,4 @@
-{% extends "/189473-sources-updates/mvp/layouts/content_layout.njk" %}
+{% extends "/194384-data-page/mvp/layouts/content_layout.njk" %}
 
 {# Custom block for the main content area of this page #}
 {% block contentContent %}

--- a/app/views/194384-data-page/mvp/pages/fiat-information.njk
+++ b/app/views/194384-data-page/mvp/pages/fiat-information.njk
@@ -3,7 +3,6 @@
 {# Custom block for the main content area of this page #}
 {% block contentContent %}
 
-{# Sub-nav to flick through data sets #}
 <p class="govuk-body">
     Find information about academies and trusts (FIAT) brings together data from different places.
 </p>

--- a/app/views/194384-data-page/mvp/parts/rsd-footer.njk
+++ b/app/views/194384-data-page/mvp/parts/rsd-footer.njk
@@ -5,12 +5,15 @@
         <div class="govuk-footer__section govuk-grid-column-one-half">
             <h2 class="govuk-footer__heading govuk-heading-m">Get help</h2>
             <ul class="govuk-footer__list govuk-footer__list--column-1">
-            <li class="govuk-footer__list-item">
-                <a class="govuk-footer__link" href="#" target="_blank">
-                Email Service Support for help with using this system
-                </a>
-                <p>We aim to respond within 5 working days, or one working day for more urgent queries.</p>
-            </li>
+                <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="#" target="_blank">
+                    Email Service Support for help with using this system
+                    </a>
+                    <p>We aim to respond within 5 working days, or one working day for more urgent queries.</p>
+                </li>
+                <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="fiat-information" target="_blank">Learn about the data we use</a>
+                </li>
             </ul>
         </div>
         <div class="govuk-footer__section govuk-grid-column-one-half">
@@ -23,12 +26,12 @@
                 classes: "rsd-footer-phase govuk-!-padding-top-0 govuk-!-padding-bottom-4"
             }) }}
             <ul class="govuk-footer__list">
-            <li class="govuk-footer__list-item">
-                <a class="govuk-footer__link" href="#" target="_blank">Give feedback (opens in a new tab)</a>
-            </li>
-            <li class="govuk-footer__list-item">
-                <a class="govuk-footer__link" href="#" target="_blank">Suggest a change (opens in a new tab)</a>
-            </li>
+                <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="#" target="_blank">Give feedback (opens in a new tab)</a>
+                </li>
+                <li class="govuk-footer__list-item">
+                    <a class="govuk-footer__link" href="#" target="_blank">Suggest a change (opens in a new tab)</a>
+                </li>
             </ul>
         </div>
         </div>

--- a/app/views/194384-data-page/mvp/parts/sources-updates.njk
+++ b/app/views/194384-data-page/mvp/parts/sources-updates.njk
@@ -62,8 +62,9 @@
     </ul>
 
     {# Link to complimentary explainer page #}
+  
     <a href="fiat-information" class="govuk-link">
-        Appropriately worded link text here
+        More about the data we use
     </a>
 
 {% endset %}


### PR DESCRIPTION
Went with "More about the data we use" for the link text. 

Changed the main page title to "About the data we use" for consistency. I think this may also work as copy for the footer link. I'll make another commit for that shortly if it looks ok.