### PR TITLE
Finance doc para and data area copy change

### DIFF
--- a/app/views/194384-data-page/mvp/pages/fiat-information.njk
+++ b/app/views/194384-data-page/mvp/pages/fiat-information.njk
@@ -3,7 +3,6 @@
 {# Custom block for the main content area of this page #}
 {% block contentContent %}
 
-{# Sub-nav to flick through data sets #}
 <p class="govuk-body">
     Find information about academies and trusts (FIAT) brings together data from different places.
 </p>

--- a/app/views/200106-finance-docs/mvp/pages/finance-checklists.njk
+++ b/app/views/200106-finance-docs/mvp/pages/finance-checklists.njk
@@ -39,20 +39,28 @@
 
   <h3 class="govuk-heading-m">Self-assessment checklists</h3>
 
+<p>You must have permission to view these documents.</p>
+
+<!--
   {# What is this document #}
   {# {{ explainerChecklists | safe }} #}
 
   {# <hr class="govuk-section-break govuk-section-break--m"> #}
+-->
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+ <!--
+         
     {# Why a document might not be available #}
-    {# {% include "/200106-finance-docs/mvp/parts/explainer-notExpected.njk" %} #}
+    {# {% include "/200106-finance-docs/mvp/parts/aboutTheseDocs.njk" %} #}
     {{ govukDetails({
       summaryText: 'Why we might not expect a document',
       html: docNotExpected
     }) }}
+    
+-->
 
     {# Internal use only warning #}
     <div class="fiat-warning-banner-a">
@@ -64,8 +72,8 @@
 
     <hr class="govuk-section-break govuk-section-break--m">
 
-    {# Sources and updates #}
-    {% include "/200106-finance-docs/mvp/parts/sourcesUpdates-checklists.njk" %}
+    {# About these documents #}
+    {% include "/200106-finance-docs/mvp/parts/aboutTheseDocs.njk" %}
 
     </div>
   </div>

--- a/app/views/200106-finance-docs/mvp/pages/finance-letters.njk
+++ b/app/views/200106-finance-docs/mvp/pages/finance-letters.njk
@@ -43,20 +43,28 @@
 
   <h3 class="govuk-heading-m">Management letters</h3>
 
+<p>You must have permission to view these documents.</p>
+
+<!--
   {# What is this document #}
   {# {{ explainerLetters | safe }} #}
 
   {# <hr class="govuk-section-break govuk-section-break--m"> #}
 
+-->  
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+
+<!--      
     {# Why a document might not be available #}
     {# {% include "/200106-finance-docs/mvp/parts/explainer-notExpected.njk" %} #}
     {{ govukDetails({
       summaryText: 'Why we might not expect a document',
       html: docNotExpected
     }) }}
+-->
 
     {# Internal use only warning #}
     <div class="fiat-warning-banner-a">
@@ -70,7 +78,7 @@
     <hr class="govuk-section-break govuk-section-break--m">
 
     {# Sources and updates #}
-    {% include "/200106-finance-docs/mvp/parts/sourcesUpdates-letters.njk" %}
+    {% include "/200106-finance-docs/mvp/parts/aboutTheseDocs.njk" %}
 
     </div>
   </div>

--- a/app/views/200106-finance-docs/mvp/pages/finance-reports.njk
+++ b/app/views/200106-finance-docs/mvp/pages/finance-reports.njk
@@ -43,13 +43,20 @@
 
   <h3 class="govuk-heading-m">Internal scrutiny reports</h3>
 
+<p>You must have permission to view these documents.</p>
+
+<!--
   {# What is this document #}
   {# {{ explainerReports | safe }} #}
 
   {# <hr class="govuk-section-break govuk-section-break--m"> #}
+-->
+
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+
+<!--
 
     {# Why a document might not be available #}
     {# {% include "/200106-finance-docs/mvp/parts/explainer-notExpected.njk" %} #}
@@ -57,6 +64,7 @@
       summaryText: 'Why we might not expect a document',
       html: docNotExpected
     }) }}
+-->
 
     {# Internal use only warning #}
     <div class="fiat-warning-banner-a">
@@ -70,7 +78,7 @@
     <hr class="govuk-section-break govuk-section-break--m">
 
     {# Sources and updates #}
-    {% include "/200106-finance-docs/mvp/parts/sourcesUpdates-reports.njk" %}
+    {% include "/200106-finance-docs/mvp/parts/aboutTheseDocs.njk" %}
 
     </div>
   </div>

--- a/app/views/200106-finance-docs/mvp/pages/finance-statements.njk
+++ b/app/views/200106-finance-docs/mvp/pages/finance-statements.njk
@@ -43,20 +43,25 @@
 
   <h3 class="govuk-heading-m">Financial statements</h3>
 
+<p>You must have permission to view these documents.</p>
+
+<!--
   {# What is this document #}
   {# {{ explainerStatements | safe }} #}
 
   {# <hr class="govuk-section-break govuk-section-break--m"> #}
-
+-->
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+<!--      
     {# Why a document might not be available #}
     {# {% include "/200106-finance-docs/mvp/parts/explainer-notExpected.njk" %} #}
     {{ govukDetails({
       summaryText: 'Why we might not expect a document',
       html: docNotExpected
     }) }}
+-->
 
     {# List of docs #}
     {% include "/200106-finance-docs/mvp/lists/list-statements.njk" %}
@@ -65,7 +70,7 @@
     <hr class="govuk-section-break govuk-section-break--m">
 
     {# Sources and updates #}
-    {% include "/200106-finance-docs/mvp/parts/sourcesUpdates-statements.njk" %}
+    {% include "/200106-finance-docs/mvp/parts/aboutTheseDocs.njk" %}
 
     </div>
   </div>

--- a/app/views/200106-finance-docs/mvp/parts/aboutTheseDocs.njk
+++ b/app/views/200106-finance-docs/mvp/parts/aboutTheseDocs.njk
@@ -1,0 +1,24 @@
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{# Set up a bunch of content for this component #}
+{% set sourceUpdatesContent %}
+       <p class="govuk-heading-s">Requesting access or reporting a problem</p>
+    <p class="govuk-body">Financial documents are maintained by the Education and Skills Funding Agency (ESFA)’s Data Science team.
+    </p>
+    <p class="govuk-body"><strong>Do not</strong> contact a trust about documents that are missing or in the wrong format.</p>
+    <p class="govuk-body">To report a problem with a document, or if you have a  <strong>business need</strong> to be granted access, email the team at:</p>
+    <p class="govuk-body"><a href="#">AcademiesFinancialMonitoring.EFA@education.gov.uk</a>.</p>
+    <p class="govuk-heading-s">Why a document might not be expected</p>
+    <p class="govuk-body">If a trust could not have submitted a document, for example because it had not formed yet, we say that it was ‘not expected’.</p>
+   
+    
+
+
+
+{% endset %}
+
+{# Display it all in a details component #}
+{{ govukDetails({
+  summaryText: "About these documents",
+  html: sourceUpdatesContent
+}) }}


### PR DESCRIPTION
In light of new information around access permissions:

- added paragraph text so users know that they might not be able to view all docs
- removed top details component so that links are not pushed below the fold
- moved the copy it contained into the bottom component
- reworked bottom component's link text and content.