### PR TITLE
Added link for sixth form Ofsted data

### DIFF
--- a/app/views/194384-data-page/mvp/pages/fiat-information.njk
+++ b/app/views/194384-data-page/mvp/pages/fiat-information.njk
@@ -121,11 +121,26 @@ Some information we take from GIAS comes from the Spring census. This gets updat
 
 
 <p>
-We take Ofsted information from the <a href="https://www.gov.uk/government/collections/maintained-schools-and-academies-inspections-and-outcomes-official-statistics">state-funded schools statistics: management information</a> report, which gets updated <strong>every month</strong>.
+We take Ofsted information from:
 </p>
 
+
+<ul class="govuk-list govuk-list--bullet">
+
+  <li>
+  <a href="https://www.gov.uk/government/collections/maintained-schools-and-academies-inspections-and-outcomes-official-statistics">State-funded schools statistics: management information</a>
+  </li>
+  <li>
+  <a href="https://www.gov.uk/government/collections/further-education-and-skills-inspection-outcomes#monthly-inspection-data">Further education and skills inspections: management information</a>
+  </li>
+  </ul>
+
+
 <p>
-Adding data from the report is a manual process. This means we cannot give an exact date for when FIAT will show it. 
+Both reports are upated <strong>every month</strong>.
+</p> 
+<p>
+Adding this data to FIAT is a manual process and we cannot give an exact date for when it be visible. 
 </p>
 
 <!--h3 Other data-->


### PR DESCRIPTION
Added a link on the explainer page showing [where the additional sixth form Ofsted data comes from](app/views/194384-data-page/mvp/pages/fiat-information.njk). 
